### PR TITLE
Update docusaurus.config.js to fix Edit-url

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -33,7 +33,7 @@ const config = {
             ({
                 docs: {
                     sidebarPath: require.resolve('./sidebars.js'),
-                    editUrl: 'https://github.com/Stirling-Tools/Stirling-PDF/tree/main/',
+                    editUrl: 'https://github.com/Stirling-Tools/Stirling-Tools.github.io/tree/main/',
                 },
                 theme: {
                     customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
This change should fix the fact that users get 404'd when trying to edit Doc pages from https://stirlingtools.com/docs using the link @ bottom of each doc page.