### PR TITLE
[SSO] fix OIDC redirect_url

### DIFF
--- a/docs/Advanced Configuration/Single Sign-On Configuration.md
+++ b/docs/Advanced Configuration/Single Sign-On Configuration.md
@@ -11,7 +11,7 @@ These are
 - ``oauth2.clientSecret`` Client Secret from your provider
 - ``oauth2.autoCreateUser`` Set this to 'true' to allow auto-creation of non-existing users
 
-The Callback URL (Redirect URL) for entering in your IdP is:  ``https://<striling-pdf.yourdomain>/oauth2/authorization/oidc`` 
+The Callback URL (Redirect URL) for entering in your IdP is:  ``https://<striling-pdf.yourdomain>/login/oauth2/code/oidc``
 
 It is highly recommended to use a SSL-enabled reverse-proxy, if the application is going to be exposed to the internet.
 


### PR DESCRIPTION
latest version of the app (v0.24.6) use another endpoint to receive the redirect after authentification than the one described in the docs.