### PR TITLE
Add 'disable_pixel' setting to 'Advanced Configuration'

### DIFF
--- a/docs/Advanced Configuration/How to add configurations.md
+++ b/docs/Advanced Configuration/How to add configurations.md
@@ -144,6 +144,9 @@ endpoints:
 metrics:
   enabled: true # 'true' to enable Info APIs (`/api/*`) endpoints, 'false' to disable
 
+disable:
+  pixel=true # 'true' to disable pixel tracking
+
 processExecutor:
   sessionLimit: # Process executor instances limits
     libreOfficeSessionLimit: 1


### PR DESCRIPTION
This PR adds the missing configuration option `DISABLE_PIXEL` to the documentation.

See also: https://github.com/Stirling-Tools/Stirling-PDF/issues/3283