### PR TITLE
Fixed outdated GitHub links & paths

### DIFF
--- a/docs/Advanced Configuration/Endpoint or Feature Customisation.md
+++ b/docs/Advanced Configuration/Endpoint or Feature Customisation.md
@@ -13,6 +13,3 @@ There are many use-cases for this such as
 To do this `ENDPOINTS_TOREMOVE` and `ENDPOINTS_GROUPSTOREMOVE` have been set up.
 They can include comma-separated lists of endpoints and groups to disable. For example, `ENDPOINTS_TOREMOVE=img-to-pdf,remove-pages` would disable both the "image to PDF" and "remove pages" functionalities.
 `ENDPOINTS_GROUPSTOREMOVE=Libre` Would disable a group of endpoints, in this case all endpoints which use Libre in the backend.
-
-A complete list of all endpoints and groups is available [here](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/Endpoint-groups.md).
-TODO?

--- a/docs/Advanced Configuration/How to add configurations.md
+++ b/docs/Advanced Configuration/How to add configurations.md
@@ -168,7 +168,7 @@ There is an additional config file ``/configs/custom_settings.yml`` where users 
 
 
 #### Extra notes
-- Endpoints. Currently, the endpoints ENDPOINTS_TOREMOVE and ENDPOINTS_GROUPSTOREMOVE can include comma separate lists of endpoints and groups to disable as example ENDPOINTS_TOREMOVE=img-to-pdf,remove-pages would disable both image-to-pdf and remove pages, ENDPOINTS_GROUPSTOREMOVE=LibreOffice Would disable all things that use LibreOffice. You can see a list of all endpoints and groups [here](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/Endpoint-groups.md)
+- Endpoints. Currently, the endpoints ENDPOINTS_TOREMOVE and ENDPOINTS_GROUPSTOREMOVE can include comma separate lists of endpoints and groups to disable as example ENDPOINTS_TOREMOVE=img-to-pdf,remove-pages would disable both image-to-pdf and remove pages, ENDPOINTS_GROUPSTOREMOVE=LibreOffice Would disable all things that use LibreOffice.
 - customStaticFilePath. Customise static files such as the app logo by placing files in the /customFiles/static/ directory. An example of customising app logo is placing a /customFiles/static/favicon.svg to override current SVG. This can be used to change any images/icons/css/fonts/js etc in Stirling-PDF
 
 ### Environment only parameters

--- a/docs/Advanced Configuration/UI Customisation.md
+++ b/docs/Advanced Configuration/UI Customisation.md
@@ -50,29 +50,29 @@ To override a file:
 3. Create the same file path under your `customFiles` directory following the same directory structure
 4. Paste and modify the contents as needed
 
-Note: When overriding templates, first copy the existing template from the [source repository](https://github.com/Stirling-Tools/Stirling-PDF/tree/main/stirling-pdf/src/main/resources/templates) to maintain the base structure.
+Note: When overriding templates, first copy the existing template from the [source repository](https://github.com/Stirling-Tools/Stirling-PDF/tree/main/app/core/src/main/resources/templates) to maintain the base structure.
 
 1. To replace the favicon:
    ```
    customFiles/static/favicon.svg
    ```
-   Original file: [stirling-pdf/src/main/resources/static/favicon.svg](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/stirling-pdf/src/main/resources/static/favicon.svg)
+   Original file: [Stirling-PDF/app/core/src/main/resources/static/favicon.svg](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/app/core/src/main/resources/static/favicon.svg)
 
 2. To override a Bootstrap icon font:
    ```
    customFiles/static/css/fonts/bootstrap-icons.woff
    ```
-   Original file: [stirling-pdf/src/main/resources/static/css/fonts/bootstrap-icons.woff](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/stirling-pdf/src/main/resources/static/css/fonts/bootstrap-icons.woff)
+   Original file: [Stirling-PDF/app/core/src/main/resources/static/css/fonts/bootstrap-icons.woff](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/app/core/src/main/resources/static/css/fonts/bootstrap-icons.woff)
 
 3. To modify a template:
    ```
    customFiles/templates/fragments/common.html
    ```
-   Original file: [stirling-pdf/src/main/resources/templates/fragments/common.html](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/stirling-pdf/src/main/resources/templates/fragments/common.html)
+   Original file: [Stirling-PDF/app/core/src/main/resources/templates/fragments/common.html](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/app/core/src/main/resources/templates/fragments/common.html)
 
 The original files can be found in the GitHub repository under:
-- Static files: [stirling-pdf/src/main/resources/static/](https://github.com/Stirling-Tools/Stirling-PDF/tree/main/stirling-pdf/src/main/resources/static)
-- Templates (HTML files): [stirling-pdf/src/main/resources/templates/](https://github.com/Stirling-Tools/Stirling-PDF/tree/main/stirling-pdf/src/main/resources/templates)
+- Static files: [Stirling-PDF/app/core/src/main/resources/static/](https://github.com/Stirling-Tools/Stirling-PDF/tree/main/app/core/src/main/resources/static)
+- Templates (HTML files): [Stirling-PDF/app/core/src/main/resources/templates/](https://github.com/Stirling-Tools/Stirling-PDF/tree/main/app/core/src/main/resources/templates)
 
 
 

--- a/docs/Contribute.md
+++ b/docs/Contribute.md
@@ -8,7 +8,7 @@ Thanks for taking a look at how to contribute to Stirling PDFs open-source codeb
 Please checkout our GitHub documentation
 
 ## Adding/Update translations
-See [How To Add New Language guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md)
+See [How To Add New Language guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md)
 
 ## Wanting to contribute to our codebase
 


### PR DESCRIPTION
Fixed some of the 404 links to the GitHub repo.

There still remain two non-working links, that point to `Endpoint-groups.md`, but I couldn't find the appropriate file. Is it still not written?